### PR TITLE
Update AEM OpenCloud version to 4.10.0

### DIFF
--- a/docs/partner_editable/deployment_options.adoc
+++ b/docs/partner_editable/deployment_options.adoc
@@ -11,5 +11,3 @@ The Quick Start provides separate templates for these options. It also lets you 
 === Operating System for Deployment
 
 This Quick Start supports Amazon Linux 2(AL2) or RedHat Enterprise Linux 7(RHEL7) for your AEM OpenCloud installation on AWS. This Quick Start deployment uses AL2.
-
-Please note that NVME instance types e.g. `m5` or `t3` are *not supported* when you run AEM OpenCloud on *RHEL7*.

--- a/scripts/ami.yaml
+++ b/scripts/ami.yaml
@@ -44,7 +44,8 @@ aem_curator::install_author::aem_jvm_opts:
 - '-XX:+HeapDumpOnOutOfMemoryError'
 
 aem_curator::install_author::data_volume_device: /dev/xvdb
-
+aem_curator::install_author::aem_ssl_method: jetty
+aem_curator::install_publish::aem_ssl_method: jetty
 aem_curator::install_publish::aem_profile: <%aem_installation_profile%>
 aem_curator::install_publish::aem_keystore_password: <%aem_keystore_password%>
 aem_curator::install_publish::aem_artifacts_base: <%s3_path%>
@@ -68,6 +69,8 @@ aem_curator::install_java::jdk_base_url: <%s3_path%>
 aem_curator::install_java::jdk_filename: <%jdk_filename%>
 aem_curator::install_java::jdk_version: <%jdk_version%>
 aem_curator::install_java::jdk_version_update: <%jdk_version_update%>
+aem_curator::install_aem_java::jdk_base_url: "%{lookup('aem_curator::install_java::jdk_base_url')}"
+aem_curator::install_aem_java::jdk_filename: "%{lookup('aem_curator::install_java::jdk_filename')}"
 
 aem_curator::install_author::aem_healthcheck_version: 1.3.3
 aem_curator::install_author::aem_healthcheck_source: <%s3_path%>

--- a/scripts/local.yaml
+++ b/scripts/local.yaml
@@ -112,7 +112,7 @@ aem_curator::config_author_primary::enable_crxde: True
 aem_curator::config_author_primary::enable_default_passwords: False
 aem_curator::config_author_primary::jvm_mem_opts: -Xss4m -Xms2048m -Xmx8192m
 aem_curator::config_author_primary::jmxremote_port: 5982
-aem_curator::config_author_primary::jvm_opts: -Dkey=value
+aem_curator::config_author_primary::jvm_opts: "-XX:+PrintGCDetails -XX:+PrintGCTimeStamps -XX:+PrintGCDateStamps -XX:+PrintTenuringDistribution -XX:+PrintGCApplicationStoppedTime -XX:+HeapDumpOnOutOfMemoryError"
 aem_curator::config_author_primary::author_timeout: 1200
 author::aem_system_users:
   admin:
@@ -155,7 +155,7 @@ author::aem_system_users:
 aem_curator::config_author_standby::aem_version: '6.5'
 aem_curator::config_author_standby::jvm_mem_opts: -Xss4m -Xms2048m -Xmx8192m
 aem_curator::config_author_standby::jmxremote_port: 5982
-aem_curator::config_author_standby::jvm_opts: -Dkey=value
+aem_curator::config_author_standby::jvm_opts: "-XX:+PrintGCDetails -XX:+PrintGCTimeStamps -XX:+PrintGCDateStamps -XX:+PrintTenuringDistribution -XX:+PrintGCApplicationStoppedTime -XX:+HeapDumpOnOutOfMemoryError"
 aem_curator::action_promote_author_standby_to_primary::aem_version: '6.5'
 ### End author-standby configuration
 
@@ -166,7 +166,7 @@ aem_curator::config_publish::enable_crxde: True
 aem_curator::config_publish::enable_default_passwords: False
 aem_curator::config_publish::jvm_mem_opts: -Xss4m -Xms2048m -Xmx8192m
 aem_curator::config_publish::jmxremote_port: 5983
-aem_curator::config_publish::jvm_opts: -Dkey=value
+aem_curator::config_publish::jvm_opts: "-XX:+PrintGCDetails -XX:+PrintGCTimeStamps -XX:+PrintGCDateStamps -XX:+PrintTenuringDistribution -XX:+PrintGCApplicationStoppedTime -XX:+HeapDumpOnOutOfMemoryError"
 aem_curator::config_publish::publish_timeout: 1200
 publish::aem_system_users:
   admin:

--- a/templates/parameters.yaml
+++ b/templates/parameters.yaml
@@ -331,7 +331,7 @@ Resources:
       Name: !Sub /${AOCStackPrefix}/version/aemawsstackprovisioner
       Description: AEM AWS Stack Provisioner Version
       Type: String
-      Value: '4.36.2'
+      Value: '4.38.0'
   AOCAemHealthcheckContentVersionParameter:
     Type: AWS::SSM::Parameter
     Properties:
@@ -784,7 +784,7 @@ Resources:
       Name: !Sub /${AOCStackPrefix}/version/packeraem
       Description: Packer AEM Version
       Type: String
-      Value: '4.26.0'
+      Value: '4.27.0'
   AOCS3DataBucketNameParameter:
     Type: AWS::SSM::Parameter
     Properties:


### PR DESCRIPTION
Description of changes:

Upgrading to the latest version of AEM OpenCloud (4.10.0), which includes the following changes:

    Critical bugfix to fix the AMI creation process.
    Add NVME instance types support for RHEL7.
    Fix default AEM JVM Options.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.